### PR TITLE
Remove MYMETA.yml/MYMETA.json from distribution packaging:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+MYMETA.yml
+MYMETA.json

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -23,3 +23,5 @@ cover_db
 ^\._.*$
 \.shipit
 \.git.*
+MYMETA.yml
+MYMETA.json


### PR DESCRIPTION
MYMETA.yml and MYMETA.json are files used internally and shouldn't
be available in the distribution release.

For further context:
http://weblog.bulknews.net/post/44251476706/stop-shipping-mymeta-to-cpan
